### PR TITLE
Fix error when gd->file_name returns NULL

### DIFF
--- a/editorconfig-geany.c
+++ b/editorconfig-geany.c
@@ -71,7 +71,7 @@ load_editorconfig(const GeanyDocument* gd)
     memset(&ecConf, 0, sizeof(ecConf));
 
     /* start parsing */
-    if ((err_num = editorconfig_parse(gd->file_name, eh)) != 0 &&
+    if ((err_num = editorconfig_parse(DOC_FILENAME(gd), eh)) != 0 &&
             /* Ignore full path error, whose error code is
              * EDITORCONFIG_PARSE_NOT_FULL_PATH */
             err_num != EDITORCONFIG_PARSE_NOT_FULL_PATH) {


### PR DESCRIPTION
When there is no file in the current session, gd->file_name returns NULL and may cause seg fault. The macro DOC_FILENAME returns a string "untitled" when gd->file_name is NULL, so it is safer.