### PR TITLE
Makefile: Use pkg-config --variable=libdir to get the library directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 ifndef EDITORCONFIG_PREFIX
 	EDITORCONFIG_PREFIX = /usr/local
 endif
-TARGET_ARCHITECTURE= $(shell cc -dumpmachine)
+GEANY_PLUGIN_LIBDIR = `pkg-config --variable=libdir geany`/geany
 
 CC = cc
 CFLAGS = -Wall -Wextra -O2 -g -fPIC `pkg-config --cflags geany` -I${EDITORCONFIG_PREFIX}/include
@@ -49,5 +49,5 @@ clean:
 
 .PHONY: install
 install: all
-	install -d $(DESTDIR)$(prefix)/usr/lib/$(TARGET_ARCHITECTURE)/geany
-	install $(TARGET_LIB) $(DESTDIR)$(prefix)/usr/lib/$(TARGET_ARCHITECTURE)/geany/$(TARGET_LIB)
+	install -d $(DESTDIR)$(prefix)$(GEANY_PLUGIN_LIBDIR)
+	install $(TARGET_LIB) $(DESTDIR)$(prefix)$(GEANY_PLUGIN_LIBDIR)/$(TARGET_LIB)


### PR DESCRIPTION
On Fedora the plugin is installed in the wrong directory.